### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-sim10 (9.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:52:52 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/gz-sim10-cli.install
+++ b/jammy/debian/gz-sim10-cli.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/gz-sim-cli.install

--- a/jammy/debian/libgz-sim10-dev.install
+++ b/jammy/debian/libgz-sim10-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sim-dev.install

--- a/jammy/debian/libgz-sim10-plugins.install
+++ b/jammy/debian/libgz-sim10-plugins.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sim-plugins.install

--- a/jammy/debian/libgz-sim10.install
+++ b/jammy/debian/libgz-sim10.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-sim.install

--- a/jammy/debian/python3-gz-sim10.install
+++ b/jammy/debian/python3-gz-sim10.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/python3-gz-sim.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.