### PR TITLE
Remove version number from some install rules

### DIFF
--- a/ubuntu/debian/libgz-sim-dev.install
+++ b/ubuntu/debian/libgz-sim-dev.install
@@ -2,4 +2,4 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-*/*
-usr/share/*/*-*[0-99]*/*-*[0-99]*.tag.xml
+usr/share/*/*-*[0-99]*/*-*.tag.xml

--- a/ubuntu/debian/libgz-sim.install
+++ b/ubuntu/debian/libgz-sim.install
@@ -1,7 +1,7 @@
 usr/lib/*/*.so.*
-usr/share/*/*-*[0-99]*/*.config
-usr/share/*/*-*[0-99]*/gui/*
-usr/share/*/*-*[0-99]*/worlds/*
-usr/share/*/*-*[0-99]*/media/*
+usr/share/*/*-*/*.config
+usr/share/*/*-*/gui/*
+usr/share/*/*-*/worlds/*
+usr/share/*/*-*/media/*
 obj-*/gz-logo[0-99]*.svg usr/share/icons/hicolor/scalable/apps/
 obj-*/gz-sim[0-99]*.desktop usr/share/applications/


### PR DESCRIPTION
Follow-up to gazebosim/gz-sim#2726.

### Currently nightly builds are failing

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-sim10-debbuilder&build=139)](https://build.osrfoundation.org/job/gz-sim10-debbuilder/139/) https://build.osrfoundation.org/job/gz-sim10-debbuilder/139/

### Test with this branch

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-sim10-debbuilder&build=140)](https://build.osrfoundation.org/job/gz-sim10-debbuilder/140/) https://build.osrfoundation.org/job/gz-sim10-debbuilder/140/