### PR TITLE
gz-sim-cli: install executable in libexec

### DIFF
--- a/ubuntu/debian/gz-sim-cli.install
+++ b/ubuntu/debian/gz-sim-cli.install
@@ -1,4 +1,5 @@
+usr/libexec/gz/sim*/*
 usr/lib/ruby/gz/*.rb
-usr/share/*/*[0-99]*.yaml
-usr/share/*/model[0-99]*.yaml
+usr/share/*/sim*.yaml
+usr/share/*/model*.yaml
 usr/share/gz/*.completion*/*


### PR DESCRIPTION
Also remove numbers from wildcards.

This helps fix unstable debbuilds (see https://github.com/gazebo-release/gz-sim10-release/pull/5#issuecomment-2762792801).