### PR TITLE
Fix lintian problems: ignore BackwardsConfig and js lintian reports

### DIFF
--- a/noble/debian/not-installed
+++ b/noble/debian/not-installed
@@ -1,0 +1,1 @@
+../../ubuntu/debian/not-installed

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -3,7 +3,7 @@ Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
 Section: science
 Priority: optional
 Build-Depends: cmake,
-               pkg-config,
+               pkgconf,
                debhelper (>= 13),
                doxygen,
                dh-python,

--- a/ubuntu/debian/not-installed
+++ b/ubuntu/debian/not-installed
@@ -1,0 +1,2 @@
+# BackwardConfig.cmake is a third-party CMake file that's not needed for packaging
+usr/lib/x86_64-linux-gnu/cmake/backward/BackwardConfig.cmake

--- a/ubuntu/debian/source/lintian-overrides
+++ b/ubuntu/debian/source/lintian-overrides
@@ -1,0 +1,2 @@
+gz-sim10 source: source-is-missing [examples/scripts/websocket_server/eventemitter2.min.js]
+gz-sim10 source: source-is-missing [examples/scripts/websocket_server/gz3d.js]


### PR DESCRIPTION
Back to enable green by ignoring the file `BackwardsConfig` it is expected not to be installed and overrides lintian complains about js files


Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-sim10-debbuilder&build=259)](https://build.osrfoundation.org/job/gz-sim10-debbuilder/259/) 