### PR TITLE
Add gz-jetty-sim alias packages

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -143,3 +143,35 @@ Description: Gazebo Sim classes and functions for robot apps - Debug symbols
  designed to rapidly develop robot applications.
  .
  Debug symbols
+
+Package: gz-jetty-sim
+Depends: libgz-sim10-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-sim-cli
+Depends: gz-sim10-cli (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-sim-plugins
+Depends: libgz-sim10-plugins (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: gz-jetty-sim-python
+Depends: python3-gz-sim10 (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.


### PR DESCRIPTION
Add gz-jetty-sim* packages that depend on the
corresponding libgz-sim10* packages.

Part of https://github.com/gazebo-tooling/release-tools/issues/1326.