### PR TITLE
Split gui and non-gui packages: new server standalone package

### DIFF
--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.0.0-1.999~noble) noble; urgency=medium
+
+  * gz-sim10 10.0.0-1.999 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Thu, 08 Jan 2026 18:49:01 +0100
+
 gz-sim10 (10.0.0-1~noble) noble; urgency=medium
 
   * gz-sim10 10.0.0-1 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.0.0-1.9992~noble) noble; urgency=medium
+
+  * gz-sim10 10.0.0-1.9992
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Tue, 20 Jan 2026 18:24:26 +0100
+
 gz-sim10 (10.0.0-1.9991~noble) noble; urgency=medium
 
   * gz-sim10 10.0.0-1.9991

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.0.0-1.9991~noble) noble; urgency=medium
+
+  * gz-sim10 10.0.0-1.9991
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 19 Jan 2026 17:44:39 +0100
+
 gz-sim10 (10.0.0-1.999~noble) noble; urgency=medium
 
   * gz-sim10 10.0.0-1.999 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.0-1.991~noble) noble; urgency=medium
+
+  * gz-sim 10.1.0-991
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Thu, 22 Jan 2026 18:19:23 +0100
+
 gz-sim10 (10.1.0-1~noble) noble; urgency=medium
 
   * gz-sim10 10.1.0-1 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.1-1.993~noble~noble) noble; urgency=medium
+
+  * gz-sim10 10.1.1-1.993~noble release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Tue, 10 Feb 2026 18:49:05 +0100
+
 gz-sim10 (10.1.1-1.992~noble) noble; urgency=medium
 
   * gz-sim10 10.1.1-1.992 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.1-1.992~noble) noble; urgency=medium
+
+  * gz-sim10 10.1.1-1.992 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Tue, 10 Feb 2026 17:57:53 +0100
+
 gz-sim10 (10.1.1-1.991~noble) noble; urgency=medium
 
   * gz-sim10 10.1.1-1.991 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.1-1.991~noble) noble; urgency=medium
+
+  * gz-sim10 10.1.1-1.991 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 09 Feb 2026 16:35:11 +0100
+
 gz-sim10 (10.1.0-1.992~noble) noble; urgency=medium
 
   * gz-sim10 10.1.0-1.992 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.1-1.995~noble) noble; urgency=medium
+
+  * gz-sim10 10.1.1-1.995 release
+
+ -- Jose Luis Rivero <jrivero@honurobotics.com>  Fri, 06 Mar 2026 22:02:54 +0100
+
 gz-sim10 (10.1.1-1.994~noble) noble; urgency=medium
 
   * gz-sim10 10.1.1-1.994 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.0-1.992~noble) noble; urgency=medium
+
+  * gz-sim10 10.1.0-1.992 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 09 Feb 2026 16:33:40 +0100
+
 gz-sim10 (10.1.0-1.991~noble) noble; urgency=medium
 
   * gz-sim 10.1.0-991

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim10 (10.1.1-1.994~noble) noble; urgency=medium
+
+  * gz-sim10 10.1.1-1.994 release
+
+ -- Jose Luis Rivero <jrivero@honurobotics.com>  Fri, 06 Mar 2026 20:03:18 +0100
+
 gz-sim10 (10.1.1-1.993~noble~noble) noble; urgency=medium
 
   * gz-sim10 10.1.1-1.993~noble release

--- a/noble/debian/gz-sim10-server.install
+++ b/noble/debian/gz-sim10-server.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/gz-sim-server.install

--- a/noble/debian/libgz-sim10-gui.install
+++ b/noble/debian/libgz-sim10-gui.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/libgz-sim-gui.install

--- a/noble/debian/libgz-sim10-plugins-gui.install
+++ b/noble/debian/libgz-sim10-plugins-gui.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/libgz-sim-plugins-gui.install

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -94,9 +94,10 @@ Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
          libgz-sim10-plugins (= ${binary:Version}),
          libgz-physics9-dartsim,
+	 libgz-rendering10-ogre2,
          ${shlibs:Depends},
          ${misc:Depends}
-Suggests: libgz-physics9-bullet, libgz-physics9-tpe
+Suggests: libgz-physics9-bullet, libgz-physics9-tpe, libgz-rendering10-ogre1
 Multi-Arch: no
 Description: Gazebo Sim classes and functions for robot apps - Server
  Gazebo Sim is a component in the Gazebo framework, a set of libraries

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -53,9 +53,24 @@ Description: Gazebo Sim classes and functions for robot apps - Shared library
  .
  Main shared library
 
+Package: libgz-sim10-gui
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: libgz-sim10 (= ${binary:Version}),
+         ${shlibs:Depends},
+         ${misc:Depends}
+Multi-Arch: same
+Description: Gazebo Sim classes and functions for robot apps - GUI library
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ GUI shared library and configuration files
+
 Package: gz-sim10-cli
 Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
+         libgz-sim10-gui (= ${binary:Version}),
          ${shlibs:Depends},
          ${misc:Depends}
 Recommends: gz-sim10-server
@@ -91,6 +106,19 @@ Description: Gazebo Sim classes and functions for robot apps - Plugins
  .
  Plugins collection
 
+Package: libgz-sim10-plugins-gui
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Recommends: libgz-sim10-plugins
+Multi-Arch: same
+Description: Gazebo Sim classes and functions for robot apps - GUI Plugins
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ GUI Plugins collection
+
 Package: libgz-sim10-dev
 Architecture: any
 Section: libdevel
@@ -116,7 +144,9 @@ Depends: libtinyxml2-dev,
          libgz-utils4-dev,
          libsdformat16-dev,
          libgz-sim10 (= ${binary:Version}),
+         libgz-sim10-gui (= ${binary:Version}),
          libgz-sim10-plugins (= ${binary:Version}),
+         libgz-sim10-plugins-gui (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Development files

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -43,8 +43,7 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         qml6-module-qtqml-models
+         ${misc:Depends}
 Recommends: gz-sim10-cli
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Shared library
@@ -58,6 +57,7 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: libgz-sim10 (= ${binary:Version}),
+         qml6-module-qtqml-models,
          ${shlibs:Depends},
          ${misc:Depends}
 Multi-Arch: same

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -90,7 +90,7 @@ Package: gz-sim10-server
 Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
          libgz-sim10-plugins (= ${binary:Version}),
-         libgz-physics9-dartsim
+         libgz-physics9-dartsim,
          ${shlibs:Depends},
          ${misc:Depends}
 Suggests: libgz-physics9-bullet, libgz-physics9-tpe

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -58,12 +58,25 @@ Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
          ${shlibs:Depends},
          ${misc:Depends}
+Recommends: gz-sim10-server
 Multi-Arch: no
 Description: Gazebo Sim classes and functions for robot apps - CLI
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
  .
  The package ships the CLI.
+
+Package: gz-sim10-server
+Architecture: any
+Depends: libgz-sim10 (= ${binary:Version}),
+         ${shlibs:Depends},
+         ${misc:Depends}
+Multi-Arch: no
+Description: Gazebo Sim classes and functions for robot apps - Server
+ Gazebo Sim is a component in the Gazebo framework, a set of libraries
+ designed to rapidly develop robot applications.
+ .
+ The package ships the simulation server.
 
 Package: libgz-sim10-plugins
 Architecture: any

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -44,7 +44,6 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends},
          ${misc:Depends}
-Recommends: gz-sim10-cli
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Shared library
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -71,9 +70,15 @@ Package: gz-sim10-cli
 Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
          libgz-sim10-gui (= ${binary:Version}),
+         libgz-sim10-plugins (= ${binary:Version}),
+         libgz-sim10-plugins-gui (= ${binary:Version}),
+         libgz-physics9-dartsim,
          ${shlibs:Depends},
          ${misc:Depends}
+# Note that the -server package hosts the standalone executable that is
+# not used to call "gz sim".
 Recommends: gz-sim10-server
+Suggests: libgz-physics9-bullet, libgz-physics9-tpe
 Multi-Arch: no
 Description: Gazebo Sim classes and functions for robot apps - CLI
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -84,21 +89,23 @@ Description: Gazebo Sim classes and functions for robot apps - CLI
 Package: gz-sim10-server
 Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
+         libgz-sim10-plugins (= ${binary:Version}),
+         libgz-physics9-dartsim
          ${shlibs:Depends},
          ${misc:Depends}
+Suggests: libgz-physics9-bullet, libgz-physics9-tpe
 Multi-Arch: no
 Description: Gazebo Sim classes and functions for robot apps - Server
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
  .
- The package ships the simulation server.
+ The package ships the simulation STANDALONE server.
 
 Package: libgz-sim10-plugins
 Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Recommends: python3-gz-sim10
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Plugins
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -148,6 +155,7 @@ Depends: libtinyxml2-dev,
          libgz-sim10-plugins (= ${binary:Version}),
          libgz-sim10-plugins-gui (= ${binary:Version}),
          ${misc:Depends}
+Recommends: python3-gz-sim10
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Development files
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -166,7 +174,7 @@ Depends: libgz-sim10 (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
-Enhances: libgz-sim10
+Enhances: libgz-sim10-dev
 Description: Gazebo Sim classes and functions for robot apps - Development files
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -60,6 +60,8 @@ Depends: libgz-sim10 (= ${binary:Version}),
          qml6-module-qtqml-models,
          ${shlibs:Depends},
          ${misc:Depends}
+Breaks: libgz-sim10 (<< 10.0.0-1.999~)
+Replaces: libgz-sim10 (<< 10.0.0-1.999~)
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - GUI library
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -107,6 +109,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Breaks: libgz-sim10 (<< 10.0.0-1.999~)
+Replaces: libgz-sim10 (<< 10.0.0-1.999~)
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Plugins
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -119,6 +123,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Breaks: libgz-sim10 (<< 10.0.0-1.999~)
+Replaces: libgz-sim10 (<< 10.0.0-1.999~)
 Recommends: libgz-sim10-plugins
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - GUI Plugins

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -60,8 +60,8 @@ Depends: libgz-sim10 (= ${binary:Version}),
          qml6-module-qtqml-models,
          ${shlibs:Depends},
          ${misc:Depends}
-Breaks: libgz-sim10 (<< 10.0.0-1.999~)
-Replaces: libgz-sim10 (<< 10.0.0-1.999~)
+Breaks: libgz-sim10 (<< 10.1.1-1.999~)
+Replaces: libgz-sim10 (<< 10.1.1-1.999~)
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - GUI library
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -111,8 +111,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Breaks: libgz-sim10 (<< 10.0.0-1.999~)
-Replaces: libgz-sim10 (<< 10.0.0-1.999~)
+Breaks: libgz-sim10 (<< 10.1.1-1.999~)
+Replaces: libgz-sim10 (<< 10.1.1-1.999~)
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Plugins
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -125,8 +125,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Breaks: libgz-sim10 (<< 10.0.0-1.999~)
-Replaces: libgz-sim10 (<< 10.0.0-1.999~)
+Breaks: libgz-sim10 (<< 10.1.1-1.999~)
+Replaces: libgz-sim10 (<< 10.1.1-1.999~)
 Recommends: libgz-sim10-plugins
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - GUI Plugins

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -60,8 +60,8 @@ Depends: libgz-sim10 (= ${binary:Version}),
          qml6-module-qtqml-models,
          ${shlibs:Depends},
          ${misc:Depends}
-Breaks: libgz-sim10 (<< 10.1.1-1.999~)
-Replaces: libgz-sim10 (<< 10.1.1-1.999~)
+Breaks: libgz-sim10 (<< 10.1.1-1.995~)
+Replaces: libgz-sim10 (<< 10.1.1-1.995~)
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - GUI library
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -111,8 +111,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Breaks: libgz-sim10 (<< 10.1.1-1.999~)
-Replaces: libgz-sim10 (<< 10.1.1-1.999~)
+Breaks: libgz-sim10 (<< 10.1.1-1.995~)
+Replaces: libgz-sim10 (<< 10.1.1-1.995~)
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - Plugins
  Gazebo Sim is a component in the Gazebo framework, a set of libraries
@@ -125,8 +125,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Breaks: libgz-sim10 (<< 10.1.1-1.999~)
-Replaces: libgz-sim10 (<< 10.1.1-1.999~)
+Breaks: libgz-sim10 (<< 10.1.1-1.995~)
+Replaces: libgz-sim10 (<< 10.1.1-1.995~)
 Recommends: libgz-sim10-plugins
 Multi-Arch: same
 Description: Gazebo Sim classes and functions for robot apps - GUI Plugins

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -94,7 +94,8 @@ Architecture: any
 Depends: libgz-sim10 (= ${binary:Version}),
          libgz-sim10-plugins (= ${binary:Version}),
          libgz-physics9-dartsim,
-	 libgz-rendering10-ogre2,
+         libgz-rendering10-ogre2,
+         libgz-sensors10-dev,
          ${shlibs:Depends},
          ${misc:Depends}
 Suggests: libgz-physics9-bullet, libgz-physics9-tpe, libgz-rendering10-ogre1

--- a/ubuntu/debian/gz-sim-cli.install
+++ b/ubuntu/debian/gz-sim-cli.install
@@ -1,4 +1,6 @@
-usr/libexec/gz/sim*/*
+usr/libexec/gz/sim10/gz-sim-gui-client
+usr/libexec/gz/sim10/gz-sim-main
+usr/libexec/gz/sim10/gz-sim-model
 usr/lib/ruby/gz/*.rb
 usr/share/*/sim*.yaml
 usr/share/*/model*.yaml

--- a/ubuntu/debian/gz-sim-server.install
+++ b/ubuntu/debian/gz-sim-server.install
@@ -1,0 +1,1 @@
+usr/libexec/gz/sim10/gz-sim-server

--- a/ubuntu/debian/libgz-sim-gui.install
+++ b/ubuntu/debian/libgz-sim-gui.install
@@ -1,2 +1,4 @@
 usr/lib/*/libgz-sim-gui.so.*
+usr/lib/*/libgz-sim-camera-video-recorder-system.so.*
+usr/lib/*/gz-sim-10/plugins/libgz-sim-camera-video-recorder-system.so*
 usr/share/*/*-*/gui/*

--- a/ubuntu/debian/libgz-sim-gui.install
+++ b/ubuntu/debian/libgz-sim-gui.install
@@ -1,0 +1,2 @@
+usr/lib/*/libgz-sim-gui.so.*
+usr/share/*/*-*/gui/*

--- a/ubuntu/debian/libgz-sim-gui.install
+++ b/ubuntu/debian/libgz-sim-gui.install
@@ -1,4 +1,3 @@
 usr/lib/*/libgz-sim-gui.so.*
 usr/lib/*/libgz-sim-camera-video-recorder-system.so.*
-usr/lib/*/gz-sim-10/plugins/libgz-sim-camera-video-recorder-system.so*
 usr/share/*/*-*/gui/*

--- a/ubuntu/debian/libgz-sim-plugins-gui.install
+++ b/ubuntu/debian/libgz-sim-plugins-gui.install
@@ -1,0 +1,1 @@
+usr/lib/*/*-*-[0-99]*/plugins/gui/*

--- a/ubuntu/debian/libgz-sim-plugins-gui.install
+++ b/ubuntu/debian/libgz-sim-plugins-gui.install
@@ -1,1 +1,2 @@
-usr/lib/*/*-*-[0-99]*/plugins/gui/*
+usr/lib/*/gz-sim-[0-99]*/plugins/gui/*
+usr/lib/*/gz-sim-[0-99]*/plugins/libgz-sim-camera-video-recorder-system.so*

--- a/ubuntu/debian/libgz-sim-plugins.install
+++ b/ubuntu/debian/libgz-sim-plugins.install
@@ -1,1 +1,1 @@
-usr/lib/*/*-*-[0-99]*/plugins/*
+usr/lib/*/*-*-[0-99]*/plugins/*.so*

--- a/ubuntu/debian/libgz-sim.install
+++ b/ubuntu/debian/libgz-sim.install
@@ -1,6 +1,5 @@
 usr/lib/*/*.so.*
 usr/share/*/*-*/*.config
-usr/share/*/*-*/gui/*
 usr/share/*/*-*/worlds/*
 usr/share/*/*-*/media/*
 obj-*/gz-logo[0-99]*.svg usr/share/icons/hicolor/scalable/apps/

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -30,6 +30,10 @@ override_dh_install:
 	$(RM) debian/gz-sim*/usr/share/gz/gz-sim*/gz-sim*.tag.xml
 	# Remove gui library in libgz-sim already in libgz-sim-gui
 	$(RM) debian/libgz-sim10/usr/lib/*/libgz-sim-gui*
+	# Remove camera-video-recorder-system in libgz-sim10 already in libgz-sim10-gui
+	$(RM) debian/libgz-sim10/usr/lib/*/libgz-sim-camera-video-recorder-system*
+	# Remove camera-video-recorder-system plugin in libgz-sim10-plugins already in libgz-sim10-gui
+	$(RM) debian/libgz-sim10-plugins/usr/lib/*/gz-sim-10/plugins/libgz-sim-camera-video-recorder-system*
 
 override_dh_auto_test:
 	# failing tests needs inspection

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -12,18 +12,8 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DUSE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION=ON \
-	-DUSE_DIST_PACKAGES_FOR_PYTHON=ON
-
-override_dh_install:
-	dh_install --
-	$(RM) debian/gz-sim*/usr/share/gz/gz-sim*/gz-sim*.tag.xml
-
-override_dh_auto_test:
-	# failing tests needs inspection
-	true
-
-override_dh_strip:
-	dh_strip -a --dbg-package=libgz-sim10-dbg
+	-DUSE_DIST_PACKAGES_FOR_PYTHON=ON \
+	-DBUILD_TESTING=OFF
 
 # Execute doc creation to export at least the doxygen tag file
 override_dh_auto_build:
@@ -34,6 +24,16 @@ override_dh_auto_install:
 	dh_auto_install
 	install -d debian/tmp/usr/share/gz/gz-sim10/
 	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-sim10/
+
+override_dh_install:
+	dh_install --
+	$(RM) debian/gz-sim*/usr/share/gz/gz-sim*/gz-sim*.tag.xml
 	# Remove gui library in libgz-sim already in libgz-sim-gui
 	$(RM) debian/libgz-sim10/usr/lib/*/libgz-sim-gui*
 
+override_dh_auto_test:
+	# failing tests needs inspection
+	true
+
+override_dh_strip:
+	dh_strip -a --dbg-package=libgz-sim10-dbg

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -34,3 +34,6 @@ override_dh_auto_install:
 	dh_auto_install
 	install -d debian/tmp/usr/share/gz/gz-sim10/
 	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-sim10/
+	# Remove gui library in libgz-sim already in libgz-sim-gui
+	$(RM) debian/libgz-sim10/usr/lib/*/libgz-sim-gui*
+

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -32,7 +32,7 @@ override_dh_install:
 	$(RM) debian/libgz-sim10/usr/lib/*/libgz-sim-gui*
 	# Remove camera-video-recorder-system in libgz-sim10 already in libgz-sim10-gui
 	$(RM) debian/libgz-sim10/usr/lib/*/libgz-sim-camera-video-recorder-system*
-	# Remove camera-video-recorder-system plugin in libgz-sim10-plugins already in libgz-sim10-gui
+	# Remove camera-video-recorder-system plugin in libgz-sim10-plugins already in libgz-sim10-plugins-gui
 	$(RM) debian/libgz-sim10-plugins/usr/lib/*/gz-sim-10/plugins/libgz-sim-camera-video-recorder-system*
 
 override_dh_auto_test:


### PR DESCRIPTION
The PR is splitting several packages to package differently the libraries and plugins that are related to the GUI (and links against gz-gui) from those that do not use it. With this:

 * `libgz-sim10`: becomes `libgz-sim` and `libgz-sim10-gui`
 * `libgz-sim10-plugin`: becomes `libgz-sim10-plugins` and 'libgz-sim10-plugins-gui`

The `gz-sim10-cli` and the `libgz-sim10-dev` packages now depends on these new gui packages with the intention of keeping the same files installed when installing the -cli or the -dev package that is usually the entry point of users installing gazebo.

There is a new **`gz-sim10-server`** that only ships the standalone `usr/libexec/gz/sim10/gz-sim-server`.  This new package needs to depend explicitly on the `libgz-sim10-plugins` package to obtain the expected plugins for the server and in some **physics** plugin package. I made mandatory the `dartsim` one and the `bullet` and `tpe` are a "Suggest:" dependencies not installed by default.

Note that these physics dependencies require: https://github.com/gazebo-release/gz-physics9-release/pull/4 to work

**Testing:**

I built this branch in:  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-sim10-debbuilder&build=320)](https://build.osrfoundation.org/job/gz-sim10-debbuilder/320/)  . Artifacts can be download and installed with dpkg -i. 

Be careful since `apt-get install -f` or other invocations could possibly need `--no-install-recommends` to avoid the GUI and Qt packages being installed.

Fix: https://github.com/gazebo-release/gz-sim8-release/issues/8